### PR TITLE
Course selector

### DIFF
--- a/manifests/lab_deps.pp
+++ b/manifests/lab_deps.pp
@@ -24,7 +24,7 @@ class lms::lab_deps{
   file { '/usr/local/bin/course_selector':
     ensure => present,
     mode   => 755,
-    source => '/usr/src/courseware-lms-content/course_selector',
+    source => '/usr/src/courseware-lms-content/scripts/course_selector.rb',
     require => Vcsrepo['/usr/src/courseware-lms-content'],
   }
 }

--- a/manifests/lab_deps.pp
+++ b/manifests/lab_deps.pp
@@ -21,4 +21,10 @@ class lms::lab_deps{
     source => '/usr/src/courseware-lms-content/hiera/hiera.yaml',
     require => Vcsrepo['/usr/src/courseware-lms-content'],
   }
+  file { '/usr/local/bin/course_selector':
+    ensure => present,
+    mode   => 755,
+    source => '/usr/src/courseware-lms-content/course_selector',
+    require => Vcsrepo['/usr/src/courseware-lms-content'],
+  }
 }


### PR DESCRIPTION
Installs the course selector script in the path where other VM scripts live.

The course selector is a simple way of setting up prerequisite files for an LMS course.

This PR depends on this getting merged - https://github.com/puppetlabs/courseware-lms-content/pull/53